### PR TITLE
Update the stac catalog metadata

### DIFF
--- a/charts/rs-server-catalog/README.md
+++ b/charts/rs-server-catalog/README.md
@@ -15,7 +15,6 @@ RS SERVER CATALOG
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | app.catalogBucket | string | `"rs-cluster-catalog"` | Object Storage bucket for the catalog |
-| app.metadata | object | `{"description":"STAC catalog of Copernicus Reference System Python","id":"rs-python","title":"RS-PYTHON STAC Catalog"}` | values used to update the catalog stac metadata |
 | app.metadata.description | string | `"STAC catalog of Copernicus Reference System Python"` | update the catalog metadata description parameter over the default one received from the pystac client |
 | app.metadata.id | string | `"rs-python"` | update the catalog metadata id parameter over the default one received from the pystac client |
 | app.metadata.title | string | `"RS-PYTHON STAC Catalog"` | update the catalog metadata title parameter over the default one received from the pystac client |

--- a/charts/rs-server-catalog/README.md
+++ b/charts/rs-server-catalog/README.md
@@ -15,6 +15,9 @@ RS SERVER CATALOG
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | app.catalogBucket | string | `"rs-cluster-catalog"` | Object Storage bucket for the catalog |
+| app.metadata.description | string | `"STAC catalog of Copernicus Reference System Python"` |  |
+| app.metadata.id | string | `"rs-python"` |  |
+| app.metadata.title | string | `"RS-PYTHON STAC Catalog"` |  |
 | app.port | int | `8000` | Port for the application |
 | app.presignedUrlExpirationTime | int | `1800` | Presigned URL expiration time in seconds. 30 min by default |
 | app.uacURL | string | `"http://apikeymanager.processing.svc.cluster.local:8000/check/api_key"` | URL of the API Key Manager service |

--- a/charts/rs-server-catalog/README.md
+++ b/charts/rs-server-catalog/README.md
@@ -15,9 +15,10 @@ RS SERVER CATALOG
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | app.catalogBucket | string | `"rs-cluster-catalog"` | Object Storage bucket for the catalog |
-| app.metadata.description | string | `"STAC catalog of Copernicus Reference System Python"` |  |
-| app.metadata.id | string | `"rs-python"` |  |
-| app.metadata.title | string | `"RS-PYTHON STAC Catalog"` |  |
+| app.metadata | object | `{"description":"STAC catalog of Copernicus Reference System Python","id":"rs-python","title":"RS-PYTHON STAC Catalog"}` | values used to update the catalog stac metadata |
+| app.metadata.description | string | `"STAC catalog of Copernicus Reference System Python"` | update the catalog metadata description parameter over the default one received from the pystac client |
+| app.metadata.id | string | `"rs-python"` | update the catalog metadata id parameter over the default one received from the pystac client |
+| app.metadata.title | string | `"RS-PYTHON STAC Catalog"` | update the catalog metadata title parameter over the default one received from the pystac client |
 | app.port | int | `8000` | Port for the application |
 | app.presignedUrlExpirationTime | int | `1800` | Presigned URL expiration time in seconds. 30 min by default |
 | app.uacURL | string | `"http://apikeymanager.processing.svc.cluster.local:8000/check/api_key"` | URL of the API Key Manager service |

--- a/charts/rs-server-catalog/templates/deployment.yaml
+++ b/charts/rs-server-catalog/templates/deployment.yaml
@@ -83,7 +83,7 @@ spec:
         - name: USE_API_HYDRATE
           value: "false"
         - name: CATALOG_METADATA_ID
-          value: "rs-python"
+          value: "{{ .Values.catalog.metadata.id }}"
         - name: CATALOG_METADATA_TITLE
           value: {{ .Values.catalog.metadata.title }}
         - name: CATALOG_METADATA_DESCRIPTION

--- a/charts/rs-server-catalog/templates/deployment.yaml
+++ b/charts/rs-server-catalog/templates/deployment.yaml
@@ -82,6 +82,12 @@ spec:
           value: "1"
         - name: USE_API_HYDRATE
           value: "false"
+        - name: CATALOG_METADATA_ID
+          value: {{ .Values.catalog.metadata.id }}
+        - name: CATALOG_METADATA_TITLE
+          value: {{ .Values.catalog.metadata.title }}
+        - name: CATALOG_METADATA_DESCRIPTION
+          value: {{ .Values.catalog.metadata.description }}
         - name: POSTGRES_HOST
           value: {{ .Values.postgres.host.rw }}
         - name: POSTGRES_PORT

--- a/charts/rs-server-catalog/templates/deployment.yaml
+++ b/charts/rs-server-catalog/templates/deployment.yaml
@@ -83,7 +83,7 @@ spec:
         - name: USE_API_HYDRATE
           value: "false"
         - name: CATALOG_METADATA_ID
-          value: {{ .Values.catalog.metadata.id }}
+          value: "rs-python"
         - name: CATALOG_METADATA_TITLE
           value: {{ .Values.catalog.metadata.title }}
         - name: CATALOG_METADATA_DESCRIPTION

--- a/charts/rs-server-catalog/templates/deployment.yaml
+++ b/charts/rs-server-catalog/templates/deployment.yaml
@@ -85,9 +85,9 @@ spec:
         - name: CATALOG_METADATA_ID
           value: "{{ .Values.catalog.metadata.id }}"
         - name: CATALOG_METADATA_TITLE
-          value: {{ .Values.catalog.metadata.title }}
+          value: "{{ .Values.catalog.metadata.title }}"
         - name: CATALOG_METADATA_DESCRIPTION
-          value: {{ .Values.catalog.metadata.description }}
+          value: "{{ .Values.catalog.metadata.description }}"
         - name: POSTGRES_HOST
           value: {{ .Values.postgres.host.rw }}
         - name: POSTGRES_PORT

--- a/charts/rs-server-catalog/templates/deployment.yaml
+++ b/charts/rs-server-catalog/templates/deployment.yaml
@@ -83,11 +83,11 @@ spec:
         - name: USE_API_HYDRATE
           value: "false"
         - name: CATALOG_METADATA_ID
-          value: "{{ .Values.catalog.metadata.id }}"
+          value: "{{ .Values.app.metadata.id }}"
         - name: CATALOG_METADATA_TITLE
-          value: "{{ .Values.catalog.metadata.title }}"
+          value: "{{ .Values.app.metadata.title }}"
         - name: CATALOG_METADATA_DESCRIPTION
-          value: "{{ .Values.catalog.metadata.description }}"
+          value: "{{ .Values.app.metadata.description }}"
         - name: POSTGRES_HOST
           value: {{ .Values.postgres.host.rw }}
         - name: POSTGRES_PORT

--- a/charts/rs-server-catalog/values.yaml
+++ b/charts/rs-server-catalog/values.yaml
@@ -31,10 +31,13 @@ app:
   catalogBucket: rs-cluster-catalog
   # -- Presigned URL expiration time in seconds. 30 min by default
   presignedUrlExpirationTime: 1800
-  # values used to update the catalog stac metadata
+  # -- values used to update the catalog stac metadata
   metadata:
+    # -- update the catalog metadata id parameter over the default one received from the pystac client
     id: "rs-python"
+    # -- update the catalog metadata title parameter over the default one received from the pystac client
     title: "RS-PYTHON STAC Catalog"
+    # -- update the catalog metadata description parameter over the default one received from the pystac client
     description: "STAC catalog of Copernicus Reference System Python"
 
 obs:

--- a/charts/rs-server-catalog/values.yaml
+++ b/charts/rs-server-catalog/values.yaml
@@ -31,6 +31,11 @@ app:
   catalogBucket: rs-cluster-catalog
   # -- Presigned URL expiration time in seconds. 30 min by default
   presignedUrlExpirationTime: 1800
+  # values used to update the catalog stac metadata
+  metadata:
+    id: "rs-python"
+    title: "RS-PYTHON STAC Catalog"
+    description: "STAC catalog of Copernicus Reference System Python"
 
 obs:
   # -- URL of the object storage service endpoint
@@ -124,9 +129,3 @@ probe:
 tempo:
   # -- Grafana tempo endpoint.
   endpoint: http://grafana-tempo-distributor.logging.svc.cluster.local:4317
-
-catalog:
-  metadata:
-    id: "rs-python"
-    title: "RS-PYTHON STAC Catalog"
-    description: "STAC catalog of Copernicus Reference System Python"

--- a/charts/rs-server-catalog/values.yaml
+++ b/charts/rs-server-catalog/values.yaml
@@ -124,3 +124,9 @@ probe:
 tempo:
   # -- Grafana tempo endpoint.
   endpoint: http://grafana-tempo-distributor.logging.svc.cluster.local:4317
+
+catalog:
+  metadata:
+    id: "rs-python"
+    title: "RS-PYTHON STAC Catalog"
+    description: "STAC catalog of Copernicus Reference System Python"

--- a/charts/rs-server-catalog/values.yaml
+++ b/charts/rs-server-catalog/values.yaml
@@ -30,8 +30,7 @@ app:
   # -- Object Storage bucket for the catalog
   catalogBucket: rs-cluster-catalog
   # -- Presigned URL expiration time in seconds. 30 min by default
-  presignedUrlExpirationTime: 1800
-  # -- values used to update the catalog stac metadata
+  presignedUrlExpirationTime: 1800  
   metadata:
     # -- update the catalog metadata id parameter over the default one received from the pystac client
     id: "rs-python"


### PR DESCRIPTION
This correlates with the same named branch (`feat-rspy282/document-stac-catalog-metadata`) from the rs-server. It follows US 282