### PR TITLE
rspy-558: Affinity and Toleration configuration for rs-server cadip and adgs

### DIFF
--- a/charts/rs-server-adgs/templates/deployment.yaml
+++ b/charts/rs-server-adgs/templates/deployment.yaml
@@ -194,4 +194,12 @@ spec:
         - name: search-service-config-volume
           configMap:
             name: {{ .Release.Name }}-search-service-config
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   revisionHistoryLimit: 10

--- a/charts/rs-server-cadip/templates/deployment.yaml
+++ b/charts/rs-server-cadip/templates/deployment.yaml
@@ -196,4 +196,11 @@ spec:
         - name: search-service-config-volume
           configMap:
             name: {{ .Release.Name }}-search-service-config
-  
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}


### PR DESCRIPTION
Affinity and Toleration configuration for rs-server-cadip and rs-server-adgs should be configurable from helm deployment.
