### PR TITLE
RSPY-555 - Add Absolute path for adgsSearchconfigFile

### DIFF
--- a/charts/rs-server-adgs/templates/deployment.yaml
+++ b/charts/rs-server-adgs/templates/deployment.yaml
@@ -97,7 +97,7 @@ spec:
         - name: S3_REGION
           value: {{ .Values.obs.region }}
         - name: RSPY_ADGS_SEARCH_CONFIG
-          value: '{{ .Values.app.adgsSearchConfigFile }}'
+          value: {{ .Values.app.confDir }}/{{ .Values.app.adgsSearchConfigFile }}
         - name: RSPY_USE_MODULE_FOR_STATION_TOKEN
           value: '{{ .Values.app.useTokenModule }}'
         - name: STAC_BROWSER_URLS


### PR DESCRIPTION
Previous update were not sufficient to fix issue.
We have to define the path to adgsSearchconfigFile as it is done for RSPY_STATION_CONFIG  and EODAG_ADGS_CONFIG/EODAG_ADGS_CONFIG
