### PR TITLE
RSPY-596 - Update to stac-browser 3.3.0

### DIFF
--- a/charts/stac-browser/README.md
+++ b/charts/stac-browser/README.md
@@ -17,7 +17,8 @@ STAC BROWSER
 | app.SB_allowExternalAccess | string | `"false"` | Allows or disallows loading and browsing external STAC data |
 | app.SB_catalogUrl | string | `"https://subdomain.example.com/catalog/"` | URL of the STAC catalog |
 | app.SB_detectLocaleFromBrowser | string | `"true"` | Detect locale from user |
-| app.SB_historyMode | string | `"history"` | Allows search engines to better crawl STAC Browser |
+| app.SB_historyMode | string | `"history"` | Allows search engines to better crawl STAC Browser. Must be set to 'history' for OIDC |
+| app.SB_socialSharing | string | `"email,bsky,mastodon"` | Social sharing |
 | app.oidc_client_id | string | `""` | OIDC Public Client ID |
 | app.oidc_endpoint | string | `""` | OIDC End Point |
 | app.oidc_realm | string | `""` | OIDC Realm |
@@ -26,7 +27,7 @@ STAC BROWSER
 | image.name | string | `"stac-browser"` | Image name |
 | image.registry | string | `"ghcr.io"` | Image registry |
 | image.repository | string | `"rs-python"` | Image repository |
-| image.version | string | `"sha256:57ac8d7712457885c1842481d851d90eb23943e2e6709b7b9ae06dbe9666b35d"` | Image version, can be a tag or a digest |
+| image.version | string | `"sha256:eca16af07307ded914bc63776660611a12122f873a23bda15973707fba70612f"` | Image version, can be a tag or a digest |
 | ingress.enabled | bool | `true` | Enabled/Disable ingress |
 | ingress.host | string | `"stac-browser.subdomain.example.com"` | Ingress host name. |
 | ingress.issuer.name | string | `"letsencrypt-prod"` | Ingress Issuer name |

--- a/charts/stac-browser/templates/deployment.yaml
+++ b/charts/stac-browser/templates/deployment.yaml
@@ -64,12 +64,17 @@ spec:
           value: {{ .Values.app.SB_historyMode }}
         - name: SB_catalogUrl
           value: {{ .Values.app.SB_catalogUrl }}
-        - name: OIDC_ENDPOINT
-          value: {{ .Values.app.oidc_endpoint }}
-        - name: OIDC_REALM
-          value: {{ .Values.app.oidc_realm }}
-        - name: PUBLIC_CLIENT_ID
-          value: {{ .Values.app.oidc_client_id }}
+        - name: SB_authConfig
+          value: |
+            {
+              "type": "openIdConnect",
+              "openIdConnectUrl": "{{ .Values.app.oidc_endpoint }}/realms/{{ .Values.app.oidc_realm }}/.well-known/openid-configuration",
+              "oidcConfig": {
+                "client_id": "{{ .Values.app.oidc_client_id }}"
+              }
+            }
+        - name: SB_socialSharing
+          value: {{ .Values.app.SB_socialSharing }}
         securityContext:
           privileged: false
         {{ if .Values.probe }}

--- a/charts/stac-browser/values.yaml
+++ b/charts/stac-browser/values.yaml
@@ -35,10 +35,12 @@ app:
   SB_allowExternalAccess: "false"
   # -- Detect locale from user
   SB_detectLocaleFromBrowser: "true"
-  # -- Allows search engines to better crawl STAC Browser
+  # -- Allows search engines to better crawl STAC Browser. Must be set to 'history' for OIDC
   SB_historyMode: history
   # -- URL of the STAC catalog
   SB_catalogUrl: https://subdomain.example.com/catalog/
+  # -- Social sharing
+  SB_socialSharing: email,bsky,mastodon
 
 probe:
   liveness:
@@ -72,7 +74,7 @@ image:
   # -- Image name
   name: stac-browser
   # -- Image version, can be a tag or a digest
-  version: sha256:57ac8d7712457885c1842481d851d90eb23943e2e6709b7b9ae06dbe9666b35d
+  version: sha256:eca16af07307ded914bc63776660611a12122f873a23bda15973707fba70612f
   # -- Image pull policy
   PullPolicy: IfNotPresent
   #imagePullSecrets: regcred


### PR DESCRIPTION
Update to https://github.com/radiantearth/stac-browser/releases/tag/v3.3.0

Requires:
- https://github.com/RS-PYTHON/rs-server/pull/877
- https://github.com/RS-PYTHON/rs-demo/pull/88