### PR TITLE
RSPY-598 - CADIP stations and ADGS don't support lte/gte operators

### DIFF
--- a/charts/rs-server-adgs/templates/configmap.yaml
+++ b/charts/rs-server-adgs/templates/configmap.yaml
@@ -117,8 +117,8 @@ data:
               operations:
                 and:
                 - contains(Name, '{Name}')
-                - PublicationDate gte {StartPublicationDate#to_iso_utc_datetime}
-                - PublicationDate lte {StopPublicationDate#to_iso_utc_datetime}
+                - (PublicationDate gt {StartPublicationDate#to_iso_utc_datetime} or PublicationDate eq {StartPublicationDate#to_iso_utc_datetime})
+                - (PublicationDate lt {StopPublicationDate#to_iso_utc_datetime} or PublicationDate eq {StopPublicationDate#to_iso_utc_datetime})
                 - PublicationDate eq {PublicationDate#to_iso_utc_datetime}
                 - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'productType' and att/OData.CSC.StringAttribute/Value eq '{attr_ptype}')
                 - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'platformSerialIdentifier' and att/OData.CSC.StringAttribute/Value eq '{attr_serial_identif}')
@@ -236,8 +236,8 @@ data:
               operations:
                 and:
                 - contains(Name, '{Name}')
-                - PublicationDate gte {StartPublicationDate#to_iso_utc_datetime}
-                - PublicationDate lte {StopPublicationDate#to_iso_utc_datetime}
+                - (PublicationDate gt {StartPublicationDate#to_iso_utc_datetime} or PublicationDate eq {StartPublicationDate#to_iso_utc_datetime})
+                - (PublicationDate lt {StopPublicationDate#to_iso_utc_datetime} or PublicationDate eq {StopPublicationDate#to_iso_utc_datetime})
                 - PublicationDate eq {PublicationDate#to_iso_utc_datetime}
                 - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'productType' and att/OData.CSC.StringAttribute/Value eq '{attr_ptype}')
                 - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'platformSerialIdentifier' and att/OData.CSC.StringAttribute/Value eq '{attr_serial_identif}')

--- a/charts/rs-server-cadip/templates/configmap.yaml
+++ b/charts/rs-server-cadip/templates/configmap.yaml
@@ -112,8 +112,8 @@ data:
                 and:
                 - SessionId in ({SessionIds})
                 - SessionId eq {SessionId}
-                - PublicationDate gte {StartPublicationDate#to_iso_utc_datetime}
-                - PublicationDate lte {StopPublicationDate#to_iso_utc_datetime}
+                - (PublicationDate gt {StartPublicationDate#to_iso_utc_datetime} or PublicationDate eq {StartPublicationDate#to_iso_utc_datetime})
+                - (PublicationDate lt {StopPublicationDate#to_iso_utc_datetime} or PublicationDate eq {StopPublicationDate#to_iso_utc_datetime})
                 - PublicationDate eq {PublicationDate#to_iso_utc_datetime}
           pagination:
             max_items_per_page: 10000
@@ -253,8 +253,8 @@ data:
                 - SessionId eq {SessionId}
                 - Satellite eq {platform}
                 - Satellite in ({platforms})
-                - PublicationDate gte {StartPublicationDate#to_iso_utc_datetime}
-                - PublicationDate lte {StopPublicationDate#to_iso_utc_datetime}
+                - (PublicationDate gt {StartPublicationDate#to_iso_utc_datetime} or PublicationDate eq {StartPublicationDate#to_iso_utc_datetime})
+                - (PublicationDate lt {StopPublicationDate#to_iso_utc_datetime} or PublicationDate eq {StopPublicationDate#to_iso_utc_datetime})
                 - PublicationDate eq {PublicationDate#to_iso_utc_datetime}
                 - Retransfer eq {Retransfer}
           pagination:
@@ -375,8 +375,8 @@ data:
                 and:
                 - SessionId in ({SessionIds})
                 - SessionId eq {SessionId}
-                - PublicationDate gte {StartPublicationDate#to_iso_utc_datetime}
-                - PublicationDate lte {StopPublicationDate#to_iso_utc_datetime}
+                - (PublicationDate gt {StartPublicationDate#to_iso_utc_datetime} or PublicationDate eq {StartPublicationDate#to_iso_utc_datetime})
+                - (PublicationDate lt {StopPublicationDate#to_iso_utc_datetime} or PublicationDate eq {StopPublicationDate#to_iso_utc_datetime})
                 - PublicationDate eq {PublicationDate#to_iso_utc_datetime}
                 - Retransfer eq {Retransfer}
           pagination:
@@ -504,8 +504,8 @@ data:
                 - SessionId eq {SessionId}
                 - Satellite eq {platform}
                 - Satellite in ({platforms})
-                - PublicationDate gte {StartPublicationDate#to_iso_utc_datetime}
-                - PublicationDate lte {StopPublicationDate#to_iso_utc_datetime}
+                - (PublicationDate gt {StartPublicationDate#to_iso_utc_datetime} or PublicationDate eq {StartPublicationDate#to_iso_utc_datetime})
+                - (PublicationDate lt {StopPublicationDate#to_iso_utc_datetime} or PublicationDate eq {StopPublicationDate#to_iso_utc_datetime})
                 - PublicationDate eq {PublicationDate#to_iso_utc_datetime}
                 - Retransfer eq {Retransfer}
           pagination:


### PR DESCRIPTION
CADIP ICD only mentions "gt" operator, thus lte/gte operators are sadly not supported.

https://github.com/RS-PYTHON/rs-server/pull/905
https://github.com/RS-PYTHON/rs-demo/pull/90
https://github.com/RS-PYTHON/rs-helm/pull/93