### PR TITLE
Add missing type for stac license link

### DIFF
--- a/charts/mockup-processor-dpr/README.md
+++ b/charts/mockup-processor-dpr/README.md
@@ -1,6 +1,6 @@
 # mockup-processor-dpr
 
-![Version: 0.0.2-a9](https://img.shields.io/badge/Version-0.0.2--a9-informational?style=flat-square) ![AppVersion: v0.2a9](https://img.shields.io/badge/AppVersion-v0.2a9-informational?style=flat-square)
+![Version: 0.0.2-a10](https://img.shields.io/badge/Version-0.0.2--a10-informational?style=flat-square) ![AppVersion: v0.2a10](https://img.shields.io/badge/AppVersion-v0.2a10-informational?style=flat-square)
 
 MOCKUP PROCESSOR DPR
 

--- a/charts/mockup-station-adgs/README.md
+++ b/charts/mockup-station-adgs/README.md
@@ -1,6 +1,6 @@
 # mockup-station-adgs
 
-![Version: 0.0.2-a9](https://img.shields.io/badge/Version-0.0.2--a9-informational?style=flat-square) ![AppVersion: v0.2a9](https://img.shields.io/badge/AppVersion-v0.2a9-informational?style=flat-square)
+![Version: 0.0.2-a10](https://img.shields.io/badge/Version-0.0.2--a10-informational?style=flat-square) ![AppVersion: v0.2a10](https://img.shields.io/badge/AppVersion-v0.2a10-informational?style=flat-square)
 
 MOCKUP STATION ADGS
 

--- a/charts/mockup-station-cadip/README.md
+++ b/charts/mockup-station-cadip/README.md
@@ -1,6 +1,6 @@
 # mockup-station-cadip
 
-![Version: 0.0.2-a9](https://img.shields.io/badge/Version-0.0.2--a9-informational?style=flat-square) ![AppVersion: v0.2a9](https://img.shields.io/badge/AppVersion-v0.2a9-informational?style=flat-square)
+![Version: 0.0.2-a10](https://img.shields.io/badge/Version-0.0.2--a10-informational?style=flat-square) ![AppVersion: v0.2a10](https://img.shields.io/badge/AppVersion-v0.2a10-informational?style=flat-square)
 
 MOCKUP STATION CADIP
 

--- a/charts/mockup-station-lta/README.md
+++ b/charts/mockup-station-lta/README.md
@@ -1,6 +1,6 @@
 # mockup-station-lta
 
-![Version: 0.0.2-a9](https://img.shields.io/badge/Version-0.0.2--a9-informational?style=flat-square) ![AppVersion: v0.2a9](https://img.shields.io/badge/AppVersion-v0.2a9-informational?style=flat-square)
+![Version: 0.0.2-a10](https://img.shields.io/badge/Version-0.0.2--a10-informational?style=flat-square) ![AppVersion: v0.2a10](https://img.shields.io/badge/AppVersion-v0.2a10-informational?style=flat-square)
 
 MOCKUP STATION LTA
 

--- a/charts/rs-server-adgs/README.md
+++ b/charts/rs-server-adgs/README.md
@@ -1,6 +1,6 @@
 # rs-server-adgs
 
-![Version: 0.0.2-a9](https://img.shields.io/badge/Version-0.0.2--a9-informational?style=flat-square) ![AppVersion: v0.2a9](https://img.shields.io/badge/AppVersion-v0.2a9-informational?style=flat-square)
+![Version: 0.0.2-a10](https://img.shields.io/badge/Version-0.0.2--a10-informational?style=flat-square) ![AppVersion: v0.2a10](https://img.shields.io/badge/AppVersion-v0.2a10-informational?style=flat-square)
 
 RS SERVER ADGS
 

--- a/charts/rs-server-adgs/templates/configmap.yaml
+++ b/charts/rs-server-adgs/templates/configmap.yaml
@@ -349,6 +349,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -384,6 +385,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -420,6 +422,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -456,6 +459,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -492,6 +496,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -528,6 +533,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -564,6 +570,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -600,6 +607,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -636,6 +644,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -672,6 +681,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -708,6 +718,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -744,6 +755,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -780,6 +792,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -816,6 +829,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -852,6 +866,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -888,6 +903,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -924,6 +940,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -960,6 +977,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -996,6 +1014,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -1032,6 +1051,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:

--- a/charts/rs-server-cadip/README.md
+++ b/charts/rs-server-cadip/README.md
@@ -1,6 +1,6 @@
 # rs-server-cadip
 
-![Version: 0.0.2-a9](https://img.shields.io/badge/Version-0.0.2--a9-informational?style=flat-square) ![AppVersion: v0.2a9](https://img.shields.io/badge/AppVersion-v0.2a9-informational?style=flat-square)
+![Version: 0.0.2-a10](https://img.shields.io/badge/Version-0.0.2--a10-informational?style=flat-square) ![AppVersion: v0.2a10](https://img.shields.io/badge/AppVersion-v0.2a10-informational?style=flat-square)
 
 RS SERVER CADIP
 

--- a/charts/rs-server-cadip/templates/configmap.yaml
+++ b/charts/rs-server-cadip/templates/configmap.yaml
@@ -629,6 +629,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -664,6 +665,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -699,6 +701,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -735,6 +738,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -771,6 +775,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -807,6 +812,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -843,6 +849,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -879,6 +886,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -915,6 +923,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -951,6 +960,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -987,6 +997,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -1023,6 +1034,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -1059,6 +1071,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -1095,6 +1108,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -1131,6 +1145,7 @@ data:
       - rel: license
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+        type: application/pdf
       providers:
       - name: European Union/ESA/Copernicus
         roles:

--- a/charts/rs-server-catalog-db/README.md
+++ b/charts/rs-server-catalog-db/README.md
@@ -1,6 +1,6 @@
 # rs-server-catalog-db
 
-![Version: 0.0.2-a9](https://img.shields.io/badge/Version-0.0.2--a9-informational?style=flat-square) ![AppVersion: v0.2a9](https://img.shields.io/badge/AppVersion-v0.2a9-informational?style=flat-square)
+![Version: 0.0.2-a10](https://img.shields.io/badge/Version-0.0.2--a10-informational?style=flat-square) ![AppVersion: v0.2a10](https://img.shields.io/badge/AppVersion-v0.2a10-informational?style=flat-square)
 
 RS SERVER CATALOG DB
 

--- a/charts/rs-server-catalog/README.md
+++ b/charts/rs-server-catalog/README.md
@@ -1,6 +1,6 @@
 # rs-server-catalog
 
-![Version: 0.0.2-a9](https://img.shields.io/badge/Version-0.0.2--a9-informational?style=flat-square) ![AppVersion: v0.2a9](https://img.shields.io/badge/AppVersion-v0.2a9-informational?style=flat-square)
+![Version: 0.0.2-a10](https://img.shields.io/badge/Version-0.0.2--a10-informational?style=flat-square) ![AppVersion: v0.2a10](https://img.shields.io/badge/AppVersion-v0.2a10-informational?style=flat-square)
 
 RS SERVER CATALOG
 

--- a/charts/rs-server-frontend/README.md
+++ b/charts/rs-server-frontend/README.md
@@ -1,6 +1,6 @@
 # rs-server-frontend
 
-![Version: 0.0.2-a9](https://img.shields.io/badge/Version-0.0.2--a9-informational?style=flat-square) ![AppVersion: v0.2a9](https://img.shields.io/badge/AppVersion-v0.2a9-informational?style=flat-square)
+![Version: 0.0.2-a10](https://img.shields.io/badge/Version-0.0.2--a10-informational?style=flat-square) ![AppVersion: v0.2a10](https://img.shields.io/badge/AppVersion-v0.2a10-informational?style=flat-square)
 
 RS SERVER FRONTEND
 

--- a/charts/rs-server-staging/README.md
+++ b/charts/rs-server-staging/README.md
@@ -1,6 +1,6 @@
 # rs-server-staging
 
-![Version: 0.0.2-a9](https://img.shields.io/badge/Version-0.0.2--a9-informational?style=flat-square) ![AppVersion: v0.2a9](https://img.shields.io/badge/AppVersion-v0.2a9-informational?style=flat-square)
+![Version: 0.0.2-a10](https://img.shields.io/badge/Version-0.0.2--a10-informational?style=flat-square) ![AppVersion: v0.2a10](https://img.shields.io/badge/AppVersion-v0.2a10-informational?style=flat-square)
 
 RS SERVER STAGING
 

--- a/charts/rs-server-station-secrets/README.md
+++ b/charts/rs-server-station-secrets/README.md
@@ -1,6 +1,6 @@
 # rs-server-station-secrets
 
-![Version: 0.0.2-a9](https://img.shields.io/badge/Version-0.0.2--a9-informational?style=flat-square) ![AppVersion: v0.2a9](https://img.shields.io/badge/AppVersion-v0.2a9-informational?style=flat-square)
+![Version: 0.0.2-a10](https://img.shields.io/badge/Version-0.0.2--a10-informational?style=flat-square) ![AppVersion: v0.2a10](https://img.shields.io/badge/AppVersion-v0.2a10-informational?style=flat-square)
 
 RS SERVER STATION SECRETS
 

--- a/charts/stac-browser/README.md
+++ b/charts/stac-browser/README.md
@@ -1,6 +1,6 @@
 # stac-browser
 
-![Version: 0.0.2-a9](https://img.shields.io/badge/Version-0.0.2--a9-informational?style=flat-square) ![AppVersion: v0.2a9](https://img.shields.io/badge/AppVersion-v0.2a9-informational?style=flat-square)
+![Version: 0.0.2-a10](https://img.shields.io/badge/Version-0.0.2--a10-informational?style=flat-square) ![AppVersion: v0.2a10](https://img.shields.io/badge/AppVersion-v0.2a10-informational?style=flat-square)
 
 STAC BROWSER
 


### PR DESCRIPTION
https://github.com/RS-PYTHON/rs-server/pull/987

Compliance to:

> STAC-CORE-GEN-STAC-REQ-0032 – Link Type consistency with corresponding entity [Requirement]
> "type" property in "link" property shall be filled and shall reflect the actual media type of the entity it refers to.