### PR TITLE
RSPY-614 - Add describedby links to CADIP/AUXIP collections

### DIFF
--- a/charts/rs-server-adgs/templates/configmap.yaml
+++ b/charts/rs-server-adgs/templates/configmap.yaml
@@ -350,6 +350,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+        title: Auxiliary Data
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -386,6 +390,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+        title: Auxiliary Data
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -423,6 +431,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+        title: Auxiliary Data
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -460,6 +472,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+        title: Auxiliary Data
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -497,6 +513,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+        title: Auxiliary Data
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -534,6 +554,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+        title: Auxiliary Data
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -571,6 +595,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+        title: Auxiliary Data
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -608,6 +636,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+        title: Auxiliary Data
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -645,6 +677,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+        title: Auxiliary Data
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -682,6 +718,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+        title: Auxiliary Data
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -719,6 +759,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+        title: Auxiliary Data
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -756,6 +800,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+        title: Auxiliary Data
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -793,6 +841,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+        title: Auxiliary Data
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -830,6 +882,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+        title: Auxiliary Data
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -867,6 +923,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+        title: Auxiliary Data
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -904,6 +964,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+        title: Auxiliary Data
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -941,6 +1005,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+        title: Auxiliary Data
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -978,6 +1046,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+        title: Auxiliary Data
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -1015,6 +1087,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+        title: Auxiliary Data
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -1052,6 +1128,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+        title: Auxiliary Data
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:

--- a/charts/rs-server-cadip/templates/configmap.yaml
+++ b/charts/rs-server-cadip/templates/configmap.yaml
@@ -630,6 +630,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+        title: Data Acquisition
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -666,6 +670,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+        title: Data Acquisition
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -702,6 +710,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+        title: Data Acquisition
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -739,6 +751,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+        title: Data Acquisition
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -776,6 +792,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+        title: Data Acquisition
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -813,6 +833,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+        title: Data Acquisition
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -850,6 +874,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+        title: Data Acquisition
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -887,6 +915,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+        title: Data Acquisition
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -924,6 +956,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+        title: Data Acquisition
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -961,6 +997,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+        title: Data Acquisition
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -998,6 +1038,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+        title: Data Acquisition
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -1035,6 +1079,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+        title: Data Acquisition
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -1072,6 +1120,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+        title: Data Acquisition
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -1109,6 +1161,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+        title: Data Acquisition
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:
@@ -1146,6 +1202,10 @@ data:
         href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
         title: Legal notice on the use of Copernicus Sentinel Data and Service Information
         type: application/pdf
+      - rel: describedby
+        href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+        title: Data Acquisition
+        type: text/html
       providers:
       - name: European Union/ESA/Copernicus
         roles:


### PR DESCRIPTION
Compliance to:

> **STAC-CORE-GEN-REQ-0040** - Reference to documentation [Recommendation]
> EOF Service STAC implementations should use a Link object with "rel": "describedby" to reference from a Collection or Item to its documentation.

https://github.com/RS-PYTHON/rs-server/pull/991
https://github.com/RS-PYTHON/rs-helm/pull/99