### PR TITLE
RSPY-611 - update all STAC extensions to the new domain

### DIFF
--- a/charts/rs-server-adgs/templates/configmap.yaml
+++ b/charts/rs-server-adgs/templates/configmap.yaml
@@ -328,7 +328,7 @@ data:
       station: adgs
       query: null
       stac_extensions:
-      - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -369,7 +369,7 @@ data:
       station: adgs2
       query: null
       stac_extensions:
-      - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -411,7 +411,7 @@ data:
       query:
         productType: AUX_PP2
       stac_extensions:
-      - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -453,7 +453,7 @@ data:
       query:
         productType: OPER_AUX_ECMWFD_PDMC
       stac_extensions:
-      - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -495,7 +495,7 @@ data:
       query:
         productType: OPER_AUX_OBMEMC
       stac_extensions:
-      - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -537,7 +537,7 @@ data:
       query:
         productType: OPER_AUX_OBMEMC_PDMC
       stac_extensions:
-      - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -579,7 +579,7 @@ data:
       query:
         productType: OPER_AUX_PREORB_OPOD
       stac_extensions:
-      - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -621,7 +621,7 @@ data:
       query:
         productType: OPER_AUX_RESORB_OPOD
       stac_extensions:
-      - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -663,7 +663,7 @@ data:
       query:
         productType: OPER_AUX_RESORB_OPODs
       stac_extensions:
-      - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -705,7 +705,7 @@ data:
       query:
         productType: OPER_MPL_ORBPRE
       stac_extensions:
-      - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -747,7 +747,7 @@ data:
       query:
         productType: OPER_MPL_ORBSCT
       stac_extensions:
-      - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -789,7 +789,7 @@ data:
       query:
         productType: AUX_PP2
       stac_extensions:
-      - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -831,7 +831,7 @@ data:
       query:
         productType: OPER_AUX_ECMWFD_PDMC
       stac_extensions:
-      - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -873,7 +873,7 @@ data:
       query:
         productType: OPER_AUX_OBMEMC
       stac_extensions:
-      - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -915,7 +915,7 @@ data:
       query:
         productType: OPER_AUX_OBMEMC_PDMC
       stac_extensions:
-      - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -957,7 +957,7 @@ data:
       query:
         productType: OPER_AUX_PREORB_OPOD
       stac_extensions:
-      - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -999,7 +999,7 @@ data:
       query:
         productType: OPER_AUX_RESORB_OPOD
       stac_extensions:
-      - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -1041,7 +1041,7 @@ data:
       query:
         productType: OPER_AUX_RESORB_OPODs
       stac_extensions:
-      - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -1083,7 +1083,7 @@ data:
       query:
         productType: OPER_MPL_ORBPRE
       stac_extensions:
-      - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -1125,7 +1125,7 @@ data:
       query:
         productType: OPER_MPL_ORBSCT
       stac_extensions:
-      - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json

--- a/charts/rs-server-cadip/templates/configmap.yaml
+++ b/charts/rs-server-cadip/templates/configmap.yaml
@@ -609,7 +609,7 @@ data:
       station: cadip
       query: null
       stac_extensions:
-      - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -650,7 +650,7 @@ data:
       station: mti
       query: null
       stac_extensions:
-      - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -691,7 +691,7 @@ data:
       station: sgs
       query: null
       stac_extensions:
-      - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -733,7 +733,7 @@ data:
       query:
         Satellite: S1A, S1B, S1C
       stac_extensions:
-      - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -775,7 +775,7 @@ data:
       query:
         Satellite: S2A, S2B, S2C
       stac_extensions:
-      - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -817,7 +817,7 @@ data:
       query:
         Satellite: S3A, S3B
       stac_extensions:
-      - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -859,7 +859,7 @@ data:
       query:
         Satellite: S5P
       stac_extensions:
-      - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -901,7 +901,7 @@ data:
       query:
         Satellite: S1A, S1B, S1C
       stac_extensions:
-      - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -943,7 +943,7 @@ data:
       query:
         Satellite: S2A, S2B, S2C
       stac_extensions:
-      - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -985,7 +985,7 @@ data:
       query:
         Satellite: S3A, S3B
       stac_extensions:
-      - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -1027,7 +1027,7 @@ data:
       query:
         Satellite: S5P
       stac_extensions:
-      - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -1069,7 +1069,7 @@ data:
       query:
         Satellite: S1A, S1B, S1C
       stac_extensions:
-      - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -1111,7 +1111,7 @@ data:
       query:
         Satellite: S2A, S2B, S2C
       stac_extensions:
-      - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -1153,7 +1153,7 @@ data:
       query:
         Satellite: S3A, S3B
       stac_extensions:
-      - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -1195,7 +1195,7 @@ data:
       query:
         Satellite: S5P
       stac_extensions:
-      - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+      - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
       - https://stac-extensions.github.io/eo/v1.0.0/schema.json
       - https://stac-extensions.github.io/projection/v1.0.0/schema.json
       - https://stac-extensions.github.io/view/v1.0.0/schema.json


### PR DESCRIPTION
Required for CORS compatibility with stac-browser

https://github.com/RS-PYTHON/rs-server/pull/1162
https://github.com/RS-PYTHON/rs-helm/pull/113