### PR TITLE
RSPY-641 - Add CQL2 temporal operators support to rs-server-auxip

### DIFF
--- a/charts/rs-server-adgs/templates/configmap.yaml
+++ b/charts/rs-server-adgs/templates/configmap.yaml
@@ -140,6 +140,21 @@ data:
                 - ContentDate/Start gt {Start#to_iso_utc_datetime}
                 - ContentDate/Start eq {DatetimeStart#to_iso_utc_datetime}
                 - ContentDate/Stop lt {Stop#to_iso_utc_datetime}
+                - '{t_before}'
+                - '{t_after}'
+                - '{t_meets}'
+                - '{t_metby}'
+                - '{t_overlaps}'
+                - '{t_overlappedby}'
+                - '{t_starts}'
+                - '{t_startedby}'
+                - '{t_during}'
+                - '{t_contains}'
+                - '{t_finishes}'
+                - '{t_finishedby}'
+                - '{t_equals}'
+                - '{t_disjoint}'
+                - '{t_intersects}'
           sort:
             sort_by_tpl: '&$orderby={sort_param} {sort_order}'
             sort_param_mapping:
@@ -273,6 +288,21 @@ data:
                 - ContentDate/Start gt {Start#to_iso_utc_datetime}
                 - ContentDate/Start eq {DatetimeStart#to_iso_utc_datetime}
                 - ContentDate/Stop lt {Stop#to_iso_utc_datetime}
+                - '{t_before}'
+                - '{t_after}'
+                - '{t_meets}'
+                - '{t_metby}'
+                - '{t_overlaps}'
+                - '{t_overlappedby}'
+                - '{t_starts}'
+                - '{t_startedby}'
+                - '{t_during}'
+                - '{t_contains}'
+                - '{t_finishes}'
+                - '{t_finishedby}'
+                - '{t_equals}'
+                - '{t_disjoint}'
+                - '{t_intersects}'
           pagination:
             max_items_per_page: 10000
             next_page_url_tpl: '{url}?{search}&$top={items_per_page}&$skip={skip}&$expand=Attributes'


### PR DESCRIPTION
https://github.com/RS-PYTHON/rs-server/pull/1156
https://github.com/RS-PYTHON/rs-helm/pull/125
https://github.com/RS-PYTHON/rs-demo/pull/137

Add support for these CQL2 temporal operators:

```
            - "{t_before}"
            - "{t_after}"
            - "{t_meets}"
            - "{t_metby}"
            - "{t_overlaps}"
            - "{t_overlappedby}"
            - "{t_starts}"
            - "{t_startedby}"
            - "{t_during}"
            - "{t_contains}"
            - "{t_finishes}"
            - "{t_finishedby}"
            - "{t_equals}"
            - "{t_disjoint}"
            - "{t_intersects}"
```

Unfortunately pygeofilter does not support these operators:

```
    T_STARTS/T_STARTEDBY
    T_FINISHES/T_FINISHEDBY
    T_DISJOINT
```

See https://github.com/geopython/pygeofilter/issues/120