### PR TITLE
Fix: use indent instead of nindent in configmaps

### DIFF
--- a/charts/mockup-processor-dpr/README.md
+++ b/charts/mockup-processor-dpr/README.md
@@ -1,6 +1,6 @@
 # mockup-processor-dpr
 
-![Version: 0.0.2-a12](https://img.shields.io/badge/Version-0.0.2--a12-informational?style=flat-square) ![AppVersion: v0.2a12](https://img.shields.io/badge/AppVersion-v0.2a12-informational?style=flat-square)
+![Version: 0.0.2-a13](https://img.shields.io/badge/Version-0.0.2--a13-informational?style=flat-square) ![AppVersion: v0.2a13](https://img.shields.io/badge/AppVersion-v0.2a13-informational?style=flat-square)
 
 MOCKUP PROCESSOR DPR
 

--- a/charts/mockup-station-adgs/README.md
+++ b/charts/mockup-station-adgs/README.md
@@ -1,6 +1,6 @@
 # mockup-station-adgs
 
-![Version: 0.0.2-a12](https://img.shields.io/badge/Version-0.0.2--a12-informational?style=flat-square) ![AppVersion: v0.2a12](https://img.shields.io/badge/AppVersion-v0.2a12-informational?style=flat-square)
+![Version: 0.0.2-a13](https://img.shields.io/badge/Version-0.0.2--a13-informational?style=flat-square) ![AppVersion: v0.2a13](https://img.shields.io/badge/AppVersion-v0.2a13-informational?style=flat-square)
 
 MOCKUP STATION ADGS
 

--- a/charts/mockup-station-cadip/README.md
+++ b/charts/mockup-station-cadip/README.md
@@ -1,6 +1,6 @@
 # mockup-station-cadip
 
-![Version: 0.0.2-a12](https://img.shields.io/badge/Version-0.0.2--a12-informational?style=flat-square) ![AppVersion: v0.2a12](https://img.shields.io/badge/AppVersion-v0.2a12-informational?style=flat-square)
+![Version: 0.0.2-a13](https://img.shields.io/badge/Version-0.0.2--a13-informational?style=flat-square) ![AppVersion: v0.2a13](https://img.shields.io/badge/AppVersion-v0.2a13-informational?style=flat-square)
 
 MOCKUP STATION CADIP
 

--- a/charts/mockup-station-lta/README.md
+++ b/charts/mockup-station-lta/README.md
@@ -1,6 +1,6 @@
 # mockup-station-lta
 
-![Version: 0.0.2-a12](https://img.shields.io/badge/Version-0.0.2--a12-informational?style=flat-square) ![AppVersion: v0.2a12](https://img.shields.io/badge/AppVersion-v0.2a12-informational?style=flat-square)
+![Version: 0.0.2-a13](https://img.shields.io/badge/Version-0.0.2--a13-informational?style=flat-square) ![AppVersion: v0.2a13](https://img.shields.io/badge/AppVersion-v0.2a13-informational?style=flat-square)
 
 MOCKUP STATION LTA
 

--- a/charts/rs-catalog-staging-configmap/README.md
+++ b/charts/rs-catalog-staging-configmap/README.md
@@ -1,6 +1,6 @@
 # rs-catalog-staging-configmap
 
-![Version: 0.0.2-a12](https://img.shields.io/badge/Version-0.0.2--a12-informational?style=flat-square) ![AppVersion: v0.2a12](https://img.shields.io/badge/AppVersion-v0.2a12-informational?style=flat-square)
+![Version: 0.0.2-a13](https://img.shields.io/badge/Version-0.0.2--a13-informational?style=flat-square) ![AppVersion: v0.2a13](https://img.shields.io/badge/AppVersion-v0.2a13-informational?style=flat-square)
 
 RS SERVER STORAGE CONFIGMAP
 

--- a/charts/rs-catalog-staging-configmap/templates/configmap.yaml
+++ b/charts/rs-catalog-staging-configmap/templates/configmap.yaml
@@ -19,4 +19,4 @@ metadata:
   namespace: {{ .Values.namespace }}
 data:
   {{ .Values.bucketConfigFileName }}: |
-{{ .Values.expiration_bucket_csv | nindent 4 }}
+{{ .Values.expiration_bucket_csv | indent 4 }}

--- a/charts/rs-server-adgs/README.md
+++ b/charts/rs-server-adgs/README.md
@@ -1,6 +1,6 @@
 # rs-server-adgs
 
-![Version: 0.0.2-a12](https://img.shields.io/badge/Version-0.0.2--a12-informational?style=flat-square) ![AppVersion: v0.2a12](https://img.shields.io/badge/AppVersion-v0.2a12-informational?style=flat-square)
+![Version: 0.0.2-a13](https://img.shields.io/badge/Version-0.0.2--a13-informational?style=flat-square) ![AppVersion: v0.2a13](https://img.shields.io/badge/AppVersion-v0.2a13-informational?style=flat-square)
 
 RS SERVER ADGS
 

--- a/charts/rs-server-cadip/README.md
+++ b/charts/rs-server-cadip/README.md
@@ -1,6 +1,6 @@
 # rs-server-cadip
 
-![Version: 0.0.2-a12](https://img.shields.io/badge/Version-0.0.2--a12-informational?style=flat-square) ![AppVersion: v0.2a12](https://img.shields.io/badge/AppVersion-v0.2a12-informational?style=flat-square)
+![Version: 0.0.2-a13](https://img.shields.io/badge/Version-0.0.2--a13-informational?style=flat-square) ![AppVersion: v0.2a13](https://img.shields.io/badge/AppVersion-v0.2a13-informational?style=flat-square)
 
 RS SERVER CADIP
 

--- a/charts/rs-server-catalog-db/README.md
+++ b/charts/rs-server-catalog-db/README.md
@@ -1,6 +1,6 @@
 # rs-server-catalog-db
 
-![Version: 0.0.2-a12](https://img.shields.io/badge/Version-0.0.2--a12-informational?style=flat-square) ![AppVersion: v0.2a12](https://img.shields.io/badge/AppVersion-v0.2a12-informational?style=flat-square)
+![Version: 0.0.2-a13](https://img.shields.io/badge/Version-0.0.2--a13-informational?style=flat-square) ![AppVersion: v0.2a13](https://img.shields.io/badge/AppVersion-v0.2a13-informational?style=flat-square)
 
 RS SERVER CATALOG DB
 

--- a/charts/rs-server-catalog/README.md
+++ b/charts/rs-server-catalog/README.md
@@ -1,6 +1,6 @@
 # rs-server-catalog
 
-![Version: 0.0.2-a12](https://img.shields.io/badge/Version-0.0.2--a12-informational?style=flat-square) ![AppVersion: v0.2a12](https://img.shields.io/badge/AppVersion-v0.2a12-informational?style=flat-square)
+![Version: 0.0.2-a13](https://img.shields.io/badge/Version-0.0.2--a13-informational?style=flat-square) ![AppVersion: v0.2a13](https://img.shields.io/badge/AppVersion-v0.2a13-informational?style=flat-square)
 
 RS SERVER CATALOG
 

--- a/charts/rs-server-catalog/templates/configmap.yaml
+++ b/charts/rs-server-catalog/templates/configmap.yaml
@@ -23,6 +23,6 @@ metadata:
     {{- include "mychart.Labels" . | nindent 4 }}
 data:
   {{ .Values.app.bucketConfig.bucketConfigFileName }}: |
-{{ .Values.app.bucketConfig.expirationBucketCsv | nindent 4 }}
+{{ .Values.app.bucketConfig.expirationBucketCsv | indent 4 }}
 
 {{ end }}

--- a/charts/rs-server-frontend/README.md
+++ b/charts/rs-server-frontend/README.md
@@ -1,6 +1,6 @@
 # rs-server-frontend
 
-![Version: 0.0.2-a12](https://img.shields.io/badge/Version-0.0.2--a12-informational?style=flat-square) ![AppVersion: v0.2a12](https://img.shields.io/badge/AppVersion-v0.2a12-informational?style=flat-square)
+![Version: 0.0.2-a13](https://img.shields.io/badge/Version-0.0.2--a13-informational?style=flat-square) ![AppVersion: v0.2a13](https://img.shields.io/badge/AppVersion-v0.2a13-informational?style=flat-square)
 
 RS SERVER FRONTEND
 

--- a/charts/rs-server-staging/README.md
+++ b/charts/rs-server-staging/README.md
@@ -1,6 +1,6 @@
 # rs-server-staging
 
-![Version: 0.0.2-a12](https://img.shields.io/badge/Version-0.0.2--a12-informational?style=flat-square) ![AppVersion: v0.2a12](https://img.shields.io/badge/AppVersion-v0.2a12-informational?style=flat-square)
+![Version: 0.0.2-a13](https://img.shields.io/badge/Version-0.0.2--a13-informational?style=flat-square) ![AppVersion: v0.2a13](https://img.shields.io/badge/AppVersion-v0.2a13-informational?style=flat-square)
 
 RS SERVER STAGING
 

--- a/charts/rs-server-staging/templates/configmap.yaml
+++ b/charts/rs-server-staging/templates/configmap.yaml
@@ -23,6 +23,6 @@ metadata:
     {{- include "mychart.Labels" . | nindent 4 }}
 data:
   {{ .Values.app.bucketConfig.bucketConfigFileName }}: |
-{{ .Values.app.bucketConfig.expirationBucketCsv | nindent 4 }}
+{{ .Values.app.bucketConfig.expirationBucketCsv | indent 4 }}
 
 {{ end }}

--- a/charts/rs-server-station-secrets/README.md
+++ b/charts/rs-server-station-secrets/README.md
@@ -1,6 +1,6 @@
 # rs-server-station-secrets
 
-![Version: 0.0.2-a12](https://img.shields.io/badge/Version-0.0.2--a12-informational?style=flat-square) ![AppVersion: v0.2a12](https://img.shields.io/badge/AppVersion-v0.2a12-informational?style=flat-square)
+![Version: 0.0.2-a13](https://img.shields.io/badge/Version-0.0.2--a13-informational?style=flat-square) ![AppVersion: v0.2a13](https://img.shields.io/badge/AppVersion-v0.2a13-informational?style=flat-square)
 
 RS SERVER STATION SECRETS
 

--- a/charts/stac-browser/README.md
+++ b/charts/stac-browser/README.md
@@ -1,6 +1,6 @@
 # stac-browser
 
-![Version: 0.0.2-a12](https://img.shields.io/badge/Version-0.0.2--a12-informational?style=flat-square) ![AppVersion: v0.2a12](https://img.shields.io/badge/AppVersion-v0.2a12-informational?style=flat-square)
+![Version: 0.0.2-a13](https://img.shields.io/badge/Version-0.0.2--a13-informational?style=flat-square) ![AppVersion: v0.2a13](https://img.shields.io/badge/AppVersion-v0.2a13-informational?style=flat-square)
 
 STAC BROWSER
 


### PR DESCRIPTION
Short fix for an error inside configmaps templates: using 'nindent' instead of 'indent' adds a line break at the beginning of the configmap, that is not compatible with the way we access the file