### PR TITLE
RSPY-569: Add s3rspy station to rs-server-staging helm chart

### DIFF
--- a/charts/rs-server-staging/README.md
+++ b/charts/rs-server-staging/README.md
@@ -31,7 +31,7 @@ RS SERVER STAGING
 | app.endpointCadip | string | `"https://subdomain.example.com/cadip"` | Cadip server pod address |
 | app.endpointCatalog | string | `"http://rs-server-catalog.processing.svc.cluster.local:8080"` | Catalog pod address |
 | app.port | int | `8000` | Port for the application |
-| app.station | object | `{"adgs":{"type":"auxip"},"adgs2":{"type":"auxip"},"cadip":{"type":"cadip"},"mti":{"type":"cadip"},"sgs":{"type":"cadip"}}` | List of configured stations (expect a secret with the same name) |
+| app.station | object | `{"adgs":{"type":"auxip"},"adgs2":{"type":"auxip"},"cadip":{"type":"cadip"},"mti":{"type":"cadip"},"s3rspy":{"type":"s3"},"sgs":{"type":"cadip"}}` | List of configured stations (expect a secret with the same name) |
 | app.uacHomeUrl | string | `"https://apikeymanager.subdomain.example.com/docs"` | URL of the API Key Manager home page (public) |
 | app.uacUrl | string | `"http://apikeymanager.processing.svc.cluster.local:8000/auth/check_key"` | URL of the API Key Manager service (internal) |
 | auth.secret.cookie_secret | string | `""` | Random string used to encode cookie-based HTTP sessions in SessionMiddleware |

--- a/charts/rs-server-staging/values.yaml
+++ b/charts/rs-server-staging/values.yaml
@@ -62,6 +62,8 @@ app:
       type: cadip
     mti:
       type: cadip
+    s3rspy:
+      type: s3
   # -- Bucket configuration to use to monitor the lifespan and name of data buckets
   # Use an external configuration through an external configmap with the value "externalCatalogBucketConfigMapName"
   # OR


### PR DESCRIPTION
This will allow rs-server-staging pod to have access to the credentials for our s3 endpoint, saved in the secret s3rspy