### PR TITLE
Remove unused workdir for CADIP and AUXIP applications

### DIFF
--- a/charts/rs-server-adgs/README.md
+++ b/charts/rs-server-adgs/README.md
@@ -25,7 +25,6 @@ RS SERVER ADGS
 | app.stationConfigFile | string | `"stations_cfg.json"` | Station configuration file for the application |
 | app.uacURL | string | `"http://apikeymanager.processing.svc.cluster.local:8000/auth/check_key"` | URL of the API Key Manager service |
 | app.useTokenModule | bool | `false` | The way the token for the external stations is loaded: own module or let eodag to do it (set it to false) |
-| app.workDir | string | `"/app"` | Working directory for the application |
 | auth.secret.cookie_secret | string | `""` | Random string used to encode cookie-based HTTP sessions in SessionMiddleware |
 | auth.secret.oidc_client_id | string | `""` | OIDC CLient ID |
 | auth.secret.oidc_client_secret | string | `""` | OIDC Secret used to sync user info from Keycloak |

--- a/charts/rs-server-adgs/templates/deployment.yaml
+++ b/charts/rs-server-adgs/templates/deployment.yaml
@@ -52,8 +52,6 @@ spec:
             memory: {{ .Values.resources.limit.ram }}
             cpu: {{ .Values.resources.limit.cpu }}
         volumeMounts:
-        - name: workdir
-          mountPath: {{ .Values.app.workDir }}
         - name: service-config-volume
           mountPath: {{ .Values.app.confDir }}/{{ .Values.app.eodagConfigFile }}
           subPath: {{ .Values.app.eodagConfigFile }}
@@ -79,8 +77,6 @@ spec:
         env:
         - name: RSPY_UAC_CHECK_URL
           value: {{ .Values.app.uacURL }}
-        - name: RSPY_WORKING_DIR
-          value: {{ .Values.app.workDir }}
         - name: RSPY_STATION_CONFIG
           value: {{ .Values.app.confDir }}/{{ .Values.app.stationConfigFile }}
         {{ if eq .Values.app.useTokenModule true }}
@@ -150,9 +146,6 @@ spec:
       restartPolicy: Always
       securityContext: {}
       volumes:
-        - name: workdir
-          emptyDir:
-            sizeLimit: 10Gi
         - name: service-config-volume
           configMap:
             name: {{ .Release.Name }}-service-config

--- a/charts/rs-server-adgs/values.yaml
+++ b/charts/rs-server-adgs/values.yaml
@@ -25,8 +25,6 @@ service:
 app:
   # -- Port for the application
   port: 8000
-  # -- Working directory for the application
-  workDir: /app
   # -- Config directory for the application
   confDir: /app/conf
   # -- Station configuration file for the application

--- a/charts/rs-server-cadip/README.md
+++ b/charts/rs-server-cadip/README.md
@@ -24,7 +24,6 @@ RS SERVER CADIP
 | app.station.cadip.endpoint.url | object | `{"odata":"http://mockup-station-cadip-cadip.processing.svc.cluster.local:8080","token":"http://mockup-station-cadip-cadip.processing.svc.cluster.local:8080/oauth2/token"}` | CADIP station URL |
 | app.uacURL | string | `"http://apikeymanager.processing.svc.cluster.local:8000/auth/check_key"` | URL of the API Key Manager service |
 | app.useTokenModule | bool | `false` | allow EODAG to handle it (set it to false for EODAG). |
-| app.workDir | string | `"/app"` | Working directory for the application |
 | auth.secret.cookie_secret | string | `""` | Random string used to encode cookie-based HTTP sessions in SessionMiddleware |
 | auth.secret.oidc_client_id | string | `""` | OIDC CLient ID |
 | auth.secret.oidc_client_secret | string | `""` | OIDC Secret used to sync user info from Keycloak |

--- a/charts/rs-server-cadip/templates/deployment.yaml
+++ b/charts/rs-server-cadip/templates/deployment.yaml
@@ -52,8 +52,6 @@ spec:
             memory: {{ .Values.resources.limit.ram }}
             cpu: {{ .Values.resources.limit.cpu }}
         volumeMounts:
-        - name: workdir
-          mountPath: {{ .Values.app.workDir }}
         - name: service-config-volume
           mountPath: {{ .Values.app.confDir }}/{{ .Values.app.eodagConfigFile }}
           subPath: {{ .Values.app.eodagConfigFile }}
@@ -79,8 +77,6 @@ spec:
         env:
         - name: RSPY_UAC_CHECK_URL
           value: {{ .Values.app.uacURL }}
-        - name: RSPY_WORKING_DIR
-          value: {{ .Values.app.workDir }}
         #- name: RSPY_STATION_CONFIG
         #  value: {{ .Values.app.confDir }}/{{ .Values.app.stationConfigFile }}        
         {{ if eq .Values.app.useTokenModule true }}
@@ -150,9 +146,6 @@ spec:
       restartPolicy: Always
       securityContext: {}
       volumes:
-        - name: workdir
-          emptyDir:
-            sizeLimit: 10Gi
         - name: service-config-volume
           configMap:
             name: {{ .Release.Name }}-service-config

--- a/charts/rs-server-cadip/values.yaml
+++ b/charts/rs-server-cadip/values.yaml
@@ -25,8 +25,6 @@ service:
 app:
   # -- Port for the application
   port: 8000
-  # -- Working directory for the application
-  workDir: /app
   # -- Config directory for the application
   confDir: /app/conf
   # -- Cadip search configuration file for the application


### PR DESCRIPTION
RSPY_WORKING_DIR is only used to write file locks to avoid concurrent write access to the database.

As there is no database for AUXIP and CADIP applications, there is no need to allocate a volume of 10 Gb for nothing.

See also https://github.com/RS-PYTHON/rs-demo/pull/167