### PR TITLE
RSPY-766: Add S1-ARD processor

### DIFF
--- a/charts/rs-dpr-service/README.md
+++ b/charts/rs-dpr-service/README.md
@@ -26,7 +26,7 @@ RS DPR SERVICE
 | auth.secret.oidc_endpoint | string | `""` | OIDC End Point |
 | auth.secret.oidc_realm | string | `""` | OIDC Realm |
 | dask.clusterMockupName | string | `"dask-eopf-mockup"` | Dask cluster name for mockup eopf processor |
-| dask.clusterName | string | `"dask-eopf"` | Dask cluster name for real eopf processor |
+| dask.clusterNames | object | `{"RSPY_DASK_S1ARD_CLUSTER_NAME":"dask-s1ard","RSPY_DASK_S1L0_CLUSTER_NAME":"dask-l0","RSPY_DASK_S3L0_CLUSTER_NAME":"dask-l0"}` | Dask cluster names for real eopf processors |
 | dask.gateway_address | string | `"http://traefik-dask-gateway.dask-gateway.svc.cluster.local"` | Dask gateway address |
 | dask.gateway_auth_type | string | `"jupyterhub"` | Dask gateway auth type |
 | dask.jupyterhub_api_token | string | `"JUPYTER_API_TOKEN_HERE"` | Jupyter API Token when dask.jupyterhub=jupyterhub |

--- a/charts/rs-dpr-service/templates/deployment.yaml
+++ b/charts/rs-dpr-service/templates/deployment.yaml
@@ -66,10 +66,12 @@ spec:
         - secretRef:
             name: {{ .Release.Name }}-jupyterhub-api-token
         env:
-        - name: RSPY_DASK_DPR_SERVICE_CLUSTER_NAME
-          value:  {{ .Values.dask.clusterName }}
         - name: RSPY_DASK_DPR_SERVICE_MOCKUP_CLUSTER_NAME
           value:  {{ .Values.dask.clusterMockupName }}
+        {{- range $key, $value := .Values.dask.clusterNames }}
+        - name: {{ $key }}
+          value: {{ $value }}
+        {{- end }}
         - name: RSPY_UAC_CHECK_URL
           value: {{ .Values.app.uacUrl }}
         - name: RSPY_UAC_HOMEPAGE

--- a/charts/rs-dpr-service/values.yaml
+++ b/charts/rs-dpr-service/values.yaml
@@ -41,8 +41,11 @@ dask:
   gateway_auth_type: jupyterhub
   # -- Jupyter API Token when dask.jupyterhub=jupyterhub
   jupyterhub_api_token: JUPYTER_API_TOKEN_HERE
-  # -- Dask cluster name for real eopf processor
-  clusterName: dask-eopf
+  # -- Dask cluster names for real eopf processors
+  clusterNames:
+    RSPY_DASK_S1L0_CLUSTER_NAME: dask-l0
+    RSPY_DASK_S3L0_CLUSTER_NAME: dask-l0
+    RSPY_DASK_S1ARD_CLUSTER_NAME: dask-s1ard
   # -- Dask cluster name for mockup eopf processor
   clusterMockupName: dask-eopf-mockup
 


### PR DESCRIPTION
Updated rs-dpr-service Helm chart to include a dynamic amount of environment variables for processor names.